### PR TITLE
Fix: Update video API route to fetch from Vercel Blob storage

### DIFF
--- a/src/app/api/video/route.ts
+++ b/src/app/api/video/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { list } from '@vercel/blob'
+import { ERROR_MESSAGES, HTTP_STATUS } from '@/lib/constants'
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams
+    const fileName = searchParams.get('fileName')
+    
+    if (!fileName) {
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.FILENAME_REQUIRED },
+        { status: HTTP_STATUS.BAD_REQUEST }
+      )
+    }
+    
+    // List all blobs to find the one matching our filename
+    const { blobs } = await list()
+    
+    // Find the blob that matches our filename
+    const matchingBlob = blobs.find(blob => 
+      blob.pathname.includes(fileName) || blob.url.includes(fileName)
+    )
+    
+    if (!matchingBlob) {
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.VIDEO_NOT_FOUND },
+        { status: HTTP_STATUS.NOT_FOUND }
+      )
+    }
+    
+    return NextResponse.json({
+      url: matchingBlob.url,
+      fileName
+    })
+  } catch (error) {
+    console.error('Error fetching video from Vercel Blob:', error)
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.INTERNAL_SERVER_ERROR },
+      { status: HTTP_STATUS.INTERNAL_SERVER_ERROR }
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed 404 error when loading hero video on homepage
- Updated video API route to properly fetch from Vercel Blob storage instead of local files
- Added proper error handling for missing videos

## Test plan
- [x] Verify hero video loads correctly on homepage
- [x] Check network tab shows successful fetch from Vercel Blob URL
- [x] Confirm no 404 errors in console